### PR TITLE
feat(auth): Add refresh token functionality

### DIFF
--- a/src/apis/auth/auth.controller.ts
+++ b/src/apis/auth/auth.controller.ts
@@ -1,13 +1,41 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, Res, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LocalAccountDto } from 'src/entities/dtos/auth.dto';
+import { Request, Response } from 'express';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login')
-  async login(@Body() localAccountDto: LocalAccountDto) {
-    return await this.authService.login(localAccountDto);
+  async login(@Body() localAccountDto: LocalAccountDto, @Res({ passthrough: true }) res: Response) {
+    const { accessToken, refreshToken } = await this.authService.login(localAccountDto);
+    // refreshToken 쿠키 설정
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000,
+    });
+    return { accessToken };
+  }
+
+  @Post('refresh-accessToken')
+  async refreshAccessToken(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const getRefreshToken = req.cookies['refreshToken'];
+    if (!getRefreshToken) {
+      throw new UnauthorizedException('리프레시 토큰이 존재하지 않습니다.');
+    }
+
+    const { accessToken, refreshToken } = await this.authService.refreshAccessToken(getRefreshToken);
+
+    res.cookie('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: false,
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000, // 7일 동안 유지
+    });
+
+    return { accessToken };
   }
 }


### PR DESCRIPTION
- 로그인 시 RefreshToken을 쿠키에 설정합니다.
- RefreshToken을 사용하여 AccessToken을 갱신하는 기능을 추가했습니다.
- 리프레시 토큰 검증 및 유효성 검사 로직을 구현했습니다.

Refresh AccessToken #2